### PR TITLE
Expose `units` submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added cross-platform coverage path mapping for multi-OS coverage aggregation
   ({ghpr}`13`).
 * Added developer installation documentation ({ghpr}`13`).
+* Exposed `units` module as public API ({ghpr}`17`).
 
 ## AxsDB 0.1.1 (2026-02-18)
 

--- a/src/axsdb/__init__.py
+++ b/src/axsdb/__init__.py
@@ -1,3 +1,4 @@
+from . import units
 from ._version import version as __version__
 from .core import (
     AbsorptionDatabase,
@@ -28,4 +29,5 @@ __all__ = [
     "__version__",
     "get_error_handling_config",
     "set_error_handling_config",
+    "units",
 ]


### PR DESCRIPTION
This PR exposes the `units` submodule as a public API point, accessible also upon `import axsdb`.