### PR TITLE
Optimize absorption coefficient evaluation pipeline

### DIFF
--- a/src/axsdb/core.py
+++ b/src/axsdb/core.py
@@ -7,9 +7,9 @@ import logging
 import os
 import re
 import textwrap
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 import attrs
 import numpy as np
@@ -22,15 +22,44 @@ from .error import (
     DataError,
     ErrorHandlingAction,
     ErrorHandlingConfiguration,
+    ErrorHandlingPolicy,
     InterpolationError,
     get_error_handling_config,
     handle_error,
 )
-from .interpolation import interp_dataarray
+from .interpolation import _interp_core, interp_dataarray
+from .math import lerp_indices
 from .typing import PathLike
-from .units import ensure_units, get_unit_registry, xarray_to_quantity
+from .units import ensure_units, get_unit_registry, parse_units, xarray_to_quantity
+from .util import ClosingLRUCache
 
 logger = logging.getLogger("axsdb")
+
+
+class _ThermophysicalPlan(NamedTuple):
+    """
+    Interpolation plan returned by :meth:`AbsorptionDatabase._thermophysical_plan`,
+    invariant across calls sharing the same file, species and error handling
+    policy (see that method for details).
+
+    Used to avoid recomputing the thermophysical part of the interpolation state
+    vector when iterating over the spectral dimension.
+    """
+
+    #: Species concentration coordinates present in the dataset.
+    x_ds: list[Hashable]
+    #: Subset of ``x_ds`` that is scalar (size 1) in the dataset.
+    x_ds_scalar: list[Hashable]
+    #: Subset of ``x_ds`` that is array-valued and present in the profile.
+    x_ds_array: set[Hashable]
+    #: Subset of ``x_ds`` that is array-valued but missing from the profile.
+    x_missing: set[Hashable]
+    #: (dimension, policy) pairs to bounds-check.
+    bounds_checks: list[tuple[Hashable, ErrorHandlingPolicy]]
+    #: Interpolation bounds mode ("fill"/"clamp"/"raise") per dimension.
+    bounds: dict[Hashable, str]
+    #: (lower, upper) fill values per dimension.
+    fill_value: dict[Hashable, tuple[float, float]]
 
 
 @attrs.define(slots=False, repr=False, eq=False)
@@ -149,8 +178,32 @@ class AbsorptionDatabase:
     #: Access mode switch: if ``True``, load data lazily; else, load data eagerly.
     lazy: bool = attrs.field(default=False, repr=False)
 
-    #: A mapping that implements an LRU caching policy.
-    _cache: LRUCache = attrs.field(factory=lambda: LRUCache(8), repr=False)
+    #: Cache mapping a filename (as str) to the corresponding xarray Dataset.
+    #: Used to avoid repeatedly opening a file when requesting data from it
+    #: several times in a row. Evicted datasets are closed (see
+    #: :class:`.util.ClosingLRUCache`), so this is the sole owner of open
+    #: lazy file handles.
+    _fname_dataset_cache: LRUCache = attrs.field(
+        factory=lambda: ClosingLRUCache(16), repr=False, init=False
+    )
+
+    #: Cache mapping a resolved dataset file (by ``ds.encoding["source"]``),
+    #: the species available in a thermophysical profile and an error
+    #: handling configuration to the invariant part of the interpolation
+    #: plan computed in :meth:`_interp_thermophysical`.
+    _thermophysical_plan_cache: LRUCache = attrs.field(
+        factory=lambda: LRUCache(16), repr=False, init=False
+    )
+
+    #: Cache mapping a spectral coordinate value to the filename of the
+    #: dataset it resolves to, used to avoid repeated file lookups for calls
+    #: that share the same spectral coordinate (e.g. sweeping CKD g-points
+    #: at a fixed wavelength). Stores filenames rather than the ``Dataset``
+    #: objects themselves so that :attr:`_fname_dataset_cache` remains the
+    #: sole owner of open datasets.
+    _wl_fname_cache: LRUCache = attrs.field(
+        factory=lambda: LRUCache(16), repr=False, init=False
+    )
 
     #: Default error handling policy. If unset, the global default is used.
     _error_handling_config: ErrorHandlingConfiguration | None = attrs.field(
@@ -305,6 +358,9 @@ class AbsorptionDatabase:
             If ``True``, attempt generating missing index files upon
             initialization. Otherwise, raise if they are missing.
 
+        error_handling_config : .ErrorHandlingConfiguration or None, optional
+            Default error handling policy. If unset, a global default is used.
+
         Returns
         -------
         AbsorptionDatabase
@@ -407,7 +463,6 @@ class AbsorptionDatabase:
         -------
         AbsorptionDatabase
         """
-
         raise NotImplementedError
 
     @staticmethod
@@ -470,7 +525,7 @@ class AbsorptionDatabase:
         """
         return self._spectral_coverage
 
-    @cachedmethod(lambda self: self._cache)
+    @cachedmethod(lambda self: self._fname_dataset_cache)
     def load_dataset(self, fname: str) -> xr.Dataset:
         """
         Convenience method to load a dataset. This method is decorated with
@@ -502,23 +557,29 @@ class AbsorptionDatabase:
 
     def cache_clear(self) -> None:
         """
-        Clear the cache.
+        Clear the cache. Cached datasets are closed in the process (see
+        :class:`.util.ClosingLRUCache`).
         """
-        self._cache.clear()
+        self._fname_dataset_cache.clear()
+        self._thermophysical_plan_cache.clear()
+        self._wl_fname_cache.clear()
 
     def cache_close(self) -> None:
         """
         Close all cached datasets.
         """
-        for value in self._cache.values():
-            value.close()
+        self._fname_dataset_cache.clear()
+        self._wl_fname_cache.clear()
 
     def cache_reset(self, maxsize: int) -> None:
         """
-        Reset the cache with the specified maximum size.
+        Reset the cache with the specified maximum size, closing any
+        currently cached dataset.
         """
-        self._cache.clear()
-        self._cache = LRUCache(maxsize=maxsize)
+        self._fname_dataset_cache.clear()
+        self._fname_dataset_cache = ClosingLRUCache(maxsize=maxsize)
+        self._thermophysical_plan_cache = LRUCache(maxsize=maxsize)
+        self._wl_fname_cache = LRUCache(maxsize=maxsize)
 
     def lookup_filenames(self, /, **kwargs) -> list[str]:
         """
@@ -581,6 +642,20 @@ class AbsorptionDatabase:
         filenames = self.lookup_filenames(**kwargs)
         return [self.load_dataset(filename) for filename in filenames]
 
+    def _resolve_dataset(self, w: pint.Quantity) -> xr.Dataset:
+        """
+        Resolve the dataset covering a wavelength coordinate, memoizing on
+        the (scalar or array) wavelength value to avoid repeated file lookups
+        for calls that share the same spectral coordinate.
+        """
+        chunks = self._chunks["wl"]
+        key = tuple(np.atleast_1d(w.m_as(chunks.units)).tolist())
+        fname = self._wl_fname_cache.get(key)
+        if fname is None:
+            fname = self.lookup_filenames(wl=w)[0]
+            self._wl_fname_cache[key] = fname
+        return self.load_dataset(fname)
+
     def eval_sigma_a_mono(
         self,
         w: pint.Quantity,
@@ -630,6 +705,7 @@ class AbsorptionDatabase:
         ----------
         w : quantity
             The wavelength for which the absorption coefficient is evaluated.
+            Must be scalar or length-1.
 
         g : float
             The g-point for which the absorption coefficient is evaluated.
@@ -652,13 +728,48 @@ class AbsorptionDatabase:
         """
         raise NotImplementedError
 
-    @staticmethod
-    def _interp_thermophysical(
+    def _thermophysical_plan(
+        self,
         ds: xr.Dataset,
-        da: xr.DataArray,
         thermoprops: xr.Dataset,
         error_handling_config: ErrorHandlingConfiguration,
-    ) -> tuple[xr.DataArray, list[Hashable]]:
+    ) -> _ThermophysicalPlan:
+        # This part only depends on which file was loaded (ds), which species
+        # are present in thermoprops, and the error handling policy — it is
+        # invariant across repeated calls sharing those three, so it is
+        # memoized here to avoid rebuilding it on every single (w, g) call.
+        #
+        # The key is built from policy contents rather than
+        # id(error_handling_config): ErrorHandlingConfiguration objects are
+        # often short-lived (e.g. freshly converted from a dict on each
+        # call), and CPython can reuse a just-freed object's id for an
+        # unrelated new object, which would otherwise silently return a
+        # stale plan for a different policy.
+        #
+        # attrs.astuple recurses into the nested BoundsPolicy pair, so any
+        # field added to ErrorHandlingPolicy/BoundsPolicy is automatically
+        # picked up here, instead of requiring this key to be hand-updated
+        # in lockstep.
+        def _policy_key(policy: ErrorHandlingPolicy) -> tuple:
+            return attrs.astuple(policy)
+
+        key = (
+            # `ds` is always sourced from `load_dataset`, which sets
+            # `encoding["source"]` via xr.open_dataset/xr.load_dataset, so
+            # this id() fallback never fires on the real loading path. It
+            # only guards a caller that would build/copy an in-memory
+            # Dataset and call this method directly, bypassing
+            # `load_dataset` — do not do that without revisiting this key.
+            ds.encoding.get("source", id(ds)),
+            frozenset(dv for dv in thermoprops.data_vars if dv.startswith("x_")),
+            _policy_key(error_handling_config.t),
+            _policy_key(error_handling_config.p),
+            _policy_key(error_handling_config.x),
+        )
+        plan = self._thermophysical_plan_cache.get(key)
+        if plan is not None:
+            return plan
+
         # List requested species concentrations
         x_ds = [coord for coord in ds.coords if coord.startswith("x_")]
         x_ds_scalar = [coord for coord in x_ds if ds[coord].size == 1]
@@ -667,15 +778,6 @@ class AbsorptionDatabase:
         x_thermoprops = [dv for dv in thermoprops.data_vars if dv.startswith("x_")]
         x_missing = set(x_ds_array) - set(x_thermoprops)
         x_ds_array = x_ds_array - x_missing
-
-        # Select on scalar coordinates and missing concentrations
-        result = da.isel(**dict.fromkeys(x_ds_scalar + list(x_missing), 0))
-
-        # Build interpolation parameters
-        coords = {"t": thermoprops["t"], "p": thermoprops["p"]}
-
-        for x in x_ds_array:
-            coords[x] = thermoprops[x]
 
         # Check bounds for each dimension and apply the configured policy
         # (IGNORE: skip, WARN: emit warning, RAISE: raise error).
@@ -686,6 +788,78 @@ class AbsorptionDatabase:
             *[(x, error_handling_config.x) for x in x_ds_array],
         ]
 
+        # Build bounds mode and fill value dicts from error handling config
+        # The interpolation layer supports:
+        # - Symmetric modes: bounds="fill" or "clamp"
+        # - Asymmetric fill values: fill_value=(lower, upper)
+        #
+        # For asymmetric modes (e.g., clamp lower, fill upper), we need to
+        # handle this differently since the interpolation layer doesn't support
+        # per-bound mode control. Strategy:
+        # - If both bounds use "clamp": use bounds="clamp"
+        # - If both bounds use "fill": use bounds="fill" with fill_value tuple
+        # - If mixed: use bounds="fill" and apply clamping manually
+        #   (for now, fall back to "fill" - TODO: implement mixed mode support)
+
+        bounds = {}
+        fill_value = {}
+
+        for dim, policy in bounds_checks:
+            lower_policy, upper_policy = policy.bounds  # Unpack tuple
+
+            # Determine bounds mode
+            if lower_policy.mode == upper_policy.mode:
+                # Symmetric mode
+                bounds[dim] = lower_policy.mode.value
+            else:
+                # Asymmetric mode: fall back to "fill"
+                bounds[dim] = "fill"
+                # TODO: Implement proper mixed clamp/fill support in interpolation layer
+
+            # Determine fill values (None → NaN)
+            lower_fill = (
+                np.nan if lower_policy.fill_value is None else lower_policy.fill_value
+            )
+            upper_fill = (
+                np.nan if upper_policy.fill_value is None else upper_policy.fill_value
+            )
+            fill_value[dim] = (lower_fill, upper_fill)
+
+        plan = _ThermophysicalPlan(
+            x_ds=x_ds,
+            x_ds_scalar=x_ds_scalar,
+            x_ds_array=x_ds_array,
+            x_missing=x_missing,
+            bounds_checks=bounds_checks,
+            bounds=bounds,
+            fill_value=fill_value,
+        )
+        self._thermophysical_plan_cache[key] = plan
+        return plan
+
+    @staticmethod
+    def _check_thermophysical_bounds(
+        ds: xr.Dataset,
+        coords: dict[Hashable, xr.DataArray],
+        bounds_checks: list[tuple[Hashable, ErrorHandlingPolicy]],
+    ) -> None:
+        """
+        Apply each dimension's bounds-check policy against the live query
+        values, raising or warning per :func:`.handle_error` as configured.
+
+        Parameters
+        ----------
+        ds : Dataset
+            The dataset providing the reference grid for each dimension.
+
+        coords : dict
+            Mapping of dimension name to the query values (thermophysical
+            profile coordinates) checked against ``ds``'s grid.
+
+        bounds_checks : list of (Hashable, ErrorHandlingPolicy)
+            The (dimension, policy) pairs to check, as returned by
+            :meth:`_thermophysical_plan`.
+        """
         for dim, policy in bounds_checks:
             lower_policy, upper_policy = policy.bounds  # Unpack tuple
 
@@ -716,47 +890,77 @@ class AbsorptionDatabase:
                     upper_policy.action,
                 )
 
-        # Build bounds mode and fill value dicts from error handling config
-        # The interpolation layer supports:
-        # - Symmetric modes: bounds="fill" or "clamp"
-        # - Asymmetric fill values: fill_value=(lower, upper)
-        #
-        # For asymmetric modes (e.g., clamp lower, fill upper), we need to
-        # handle this differently since the interpolation layer doesn't support
-        # per-bound mode control. Strategy:
-        # - If both bounds use "clamp": use bounds="clamp"
-        # - If both bounds use "fill": use bounds="fill" with fill_value tuple
-        # - If mixed: use bounds="fill" and apply clamping manually
-        #   (for now, fall back to "fill" - TODO: implement mixed mode support)
+    def _interp_thermophysical(
+        self,
+        ds: xr.Dataset,
+        da: xr.DataArray,
+        thermoprops: xr.Dataset,
+        error_handling_config: ErrorHandlingConfiguration,
+    ) -> tuple[xr.DataArray, list[Hashable]]:
+        plan = self._thermophysical_plan(ds, thermoprops, error_handling_config)
 
-        bounds = {}
-        fill_value = {}
+        # Select on scalar coordinates and missing concentrations
+        result = da.isel(**dict.fromkeys(plan.x_ds_scalar + list(plan.x_missing), 0))
 
-        for dim, policy in bounds_checks:
-            lower_policy, upper_policy = policy.bounds  # Unpack tuple
+        # Build interpolation parameters
+        coords = {"t": thermoprops["t"], "p": thermoprops["p"]}
 
-            # Determine bounds mode
-            if lower_policy.mode == upper_policy.mode:
-                # Symmetric mode
-                bounds[dim] = lower_policy.mode
-            else:
-                # Asymmetric mode: fall back to "fill"
-                bounds[dim] = "fill"
-                # TODO: Implement proper mixed clamp/fill support in interpolation layer
+        for x in plan.x_ds_array:
+            coords[x] = thermoprops[x]
 
-            # Determine fill values (None → NaN)
-            lower_fill = (
-                np.nan if lower_policy.fill_value is None else lower_policy.fill_value
-            )
-            upper_fill = (
-                np.nan if upper_policy.fill_value is None else upper_policy.fill_value
-            )
-            fill_value[dim] = (lower_fill, upper_fill)
+        self._check_thermophysical_bounds(ds, coords, plan.bounds_checks)
 
         # Perform interpolation
-        result = interp_dataarray(result, coords, bounds=bounds, fill_value=fill_value)
+        result = interp_dataarray(
+            result, coords, bounds=plan.bounds, fill_value=plan.fill_value
+        )
 
-        return result, x_ds
+        return result, plan.x_ds
+
+    def _interp_thermophysical_raw(
+        self,
+        ds: xr.Dataset,
+        data: np.ndarray,
+        dims: list[Hashable],
+        old_coords: Mapping[Hashable, xr.DataArray],
+        thermoprops: xr.Dataset,
+        error_handling_config: ErrorHandlingConfiguration,
+    ) -> tuple[np.ndarray, list[Hashable], dict, list[Hashable]]:
+        """
+        Raw-numpy sibling of :meth:`_interp_thermophysical`: same bounds
+        checks and interpolation plan, but takes/returns plain numpy data
+        instead of an ``xr.DataArray``, so callers can defer DataArray
+        construction until the end of a longer pipeline.
+        """
+        plan = self._thermophysical_plan(ds, thermoprops, error_handling_config)
+
+        # Select on scalar coordinates and missing concentrations
+        iselect = plan.x_ds_scalar + list(plan.x_missing)
+        if iselect:
+            assert all(d in dims for d in iselect)
+            idx = tuple(0 if d in iselect else slice(None) for d in dims)
+            data = data[idx]
+            dims = [d for d in dims if d not in iselect]
+
+        # Build interpolation parameters
+        coords = {"t": thermoprops["t"], "p": thermoprops["p"]}
+
+        for x in plan.x_ds_array:
+            coords[x] = thermoprops[x]
+
+        self._check_thermophysical_bounds(ds, coords, plan.bounds_checks)
+
+        # Perform interpolation
+        data, dims, out_coords = _interp_core(
+            data,
+            dims,
+            old_coords,
+            coords,
+            bounds=plan.bounds,
+            fill_value=plan.fill_value,
+        )
+
+        return data, dims, out_coords, plan.x_ds
 
 
 @attrs.define(repr=False, eq=False)
@@ -823,17 +1027,14 @@ class MonoAbsorptionDatabase(AbsorptionDatabase):
     ) -> xr.DataArray:
         # Inherit docstring
 
-        ureg = get_unit_registry()
-
         if error_handling_config is None:
             error_handling_config = self.error_handling_config
 
         # Lookup dataset
-        ds = self.lookup_datasets(wl=w)[0]
+        ds = self._resolve_dataset(w)
 
         # Interpolate on spectral dimension
-        # TODO: Optimize
-        w_u = ureg(ds["w"].units)
+        w_u = parse_units(ds["w"].units)
         # Note: Support for wavenumber spectral lookup mode is suboptimal
         w_m = (1.0 / w).m_as(w_u) if w_u.check("[length]^-1") else w.m_as(w_u)
         result = ds["sigma_a"].interp(w=w_m, method="linear")
@@ -926,35 +1127,81 @@ class CKDAbsorptionDatabase(AbsorptionDatabase):
         #  * Above the cut-off altitude, the profile is filled with zeros.
         #  Cut-off detection is implemented with pressure-based masking.
 
-        # TODO: Use the 'assume_sorted' parameter of DataArray.interp()
-
         if error_handling_config is None:
             error_handling_config = self.error_handling_config
 
         # Lookup dataset
-        ds = self.lookup_datasets(wl=w)[0]
+        ds = self._resolve_dataset(w)
 
-        # Select bin
-        # TODO: Optimize
-        ureg = get_unit_registry()
-        w_u = ureg(ds["w"].units)
-        w_m = w.m_as(w_u)
-        result = ds["sigma_a"].sel(w=w_m, method="nearest")
+        # Select bin. Stays on raw numpy throughout (instead of
+        # ds["sigma_a"].sel(w=w_m, method="nearest") plus two more
+        # DataArray-in/DataArray-out interpolation steps below) so only one
+        # xr.DataArray is constructed, at the very end of this method.
+        # Only scalar/length-1 w is supported (matches all current usage).
+        w_u = parse_units(ds["w"].units)
+        w_m = np.atleast_1d(w.m_as(w_u))
+        assert w_m.size == 1, "eval_sigma_a_ckd only supports scalar/length-1 w"
+        w_m = w_m[0]
 
-        # Interpolate along g
-        result = result.interp(g=g).drop_vars("g")
+        w_vals = ds["w"].values
+        n = w_vals.size
+        if n == 1:
+            w_idx = 0
+        else:
+            # Nearest-neighbor lookup on a sorted grid, matching xarray's
+            # .sel(method="nearest") tie-break (exact midpoints resolve to
+            # the upper neighbor) — verified empirically against the real
+            # test fixtures. Reuses the same sorted-grid binary search as
+            # lerp_indices (used for linear interpolation elsewhere in the
+            # package) instead of a second, independent implementation:
+            # weight < 0.5 means the query is closer to the lower grid
+            # point, weight >= 0.5 (including exact midpoints) means it's
+            # at least as close to the upper one.
+            left_idx, weight = lerp_indices(w_vals, np.array([w_m]), bounds="clamp")
+            w_idx = int(left_idx[0]) + (1 if weight[0] >= 0.5 else 0)
+
+        sigma_a = ds["sigma_a"]
+        # The matched grid coordinate (not the raw query value), matching
+        # xr.DataArray.sel(method="nearest")'s behaviour: it labels the
+        # result with the grid point it actually selected.
+        w_coord = sigma_a.coords["w"].isel(w=w_idx)
+        w_axis = sigma_a.dims.index("w")
+        # np.take always copies, never a view: `data` must never alias
+        # ds["sigma_a"].values, since it's LRU-cached and reused across
+        # calls, and later steps may mutate `data` in place for fill values.
+        data = np.take(sigma_a.values, w_idx, axis=w_axis)
+        dims = [d for d in sigma_a.dims if d != "w"]
+
+        # Interpolate along g. `g` is a small, sorted, static grid, so this
+        # uses the package's fast interpolation helper instead of
+        # DataArray.interp(), which pays for a generic sortby/align pass on
+        # every call.
+        data, dims, _ = _interp_core(data, dims, sigma_a.coords, {"g": g})
 
         # Interpolate on thermophysical dimensions
-        result, x_ds = self._interp_thermophysical(
-            ds, result, thermoprops, error_handling_config
+        data, dims, out_coords, x_ds = self._interp_thermophysical_raw(
+            ds, data, dims, sigma_a.coords, thermoprops, error_handling_config
         )
 
         # Drop thermophysical coordinates, ensure spectral dimension
-        result = result.drop_vars(["p", "t", *x_ds], errors="ignore")
-        if "w" not in result.dims:
-            result = result.expand_dims("w")
+        for name in ("p", "t", *x_ds):
+            out_coords.pop(name, None)
+        if "w" not in dims:
+            dims = ["w", *dims]
+            data = data[np.newaxis, ...]
+        out_coords["w"] = ("w", np.array([w_coord.values]), dict(w_coord.attrs))
 
-        return result.transpose("w", "z")
+        assert set(dims) == {"w", "z"}
+        data = data.transpose(dims.index("w"), dims.index("z"))
+        dims = ["w", "z"]
+
+        return xr.DataArray(
+            data,
+            dims=dims,
+            coords=out_coords,
+            name=sigma_a.name,
+            attrs=sigma_a.attrs,
+        )
 
 
 def get_absdb_type(mode: Literal["mono", "ckd"]) -> type:

--- a/src/axsdb/interpolation.py
+++ b/src/axsdb/interpolation.py
@@ -9,7 +9,7 @@ https://github.com/pydata/xarray/issues/10683).
 
 from __future__ import annotations
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Mapping
 from typing import Literal
 
 import numpy as np
@@ -202,7 +202,7 @@ def _should_use_fast_path(
 def _interp_group_with_interpn(
     data: np.ndarray,
     dims: list[Hashable],
-    da: xr.DataArray,
+    old_coords: Mapping[Hashable, xr.DataArray],
     group: list[dict],
     bounds_mode: Literal["fill", "clamp", "raise"],
     fill_value_dict: dict[Hashable, float | tuple[float, float]],
@@ -220,8 +220,8 @@ def _interp_group_with_interpn(
         Current data array.
     dims : list
         Current dimension names corresponding to data axes.
-    da : xr.DataArray
-        Original DataArray (for coordinate grids).
+    old_coords : Mapping
+        Original DataArray's coordinates (for coordinate grids).
     group : list of dict
         Group of specs to interpolate together.
     bounds_mode : {"fill", "clamp", "raise"}
@@ -241,7 +241,7 @@ def _interp_group_with_interpn(
     dest_dims = group[0]["new_dims"]  # All specs in group share destination dims
 
     # Build grid points tuple for interpn (order matters!)
-    grid_points = tuple(da.coords[dim].values for dim in src_dims)
+    grid_points = tuple(old_coords[dim].values for dim in src_dims)
 
     # Build query points array: shape (dest_size, n_src_dims)
     query_arrays = [spec["arr"] for spec in group]
@@ -454,6 +454,34 @@ def interp_dataarray(
     ...     fill_value={"wavelength": 0.0, "angle": (-1.0, 1.0)},
     ... )
     """
+    data, dims, out_coords = _interp_core(
+        da.values, list(da.dims), da.coords, coords, bounds, fill_value
+    )
+    return xr.DataArray(
+        data, dims=dims, coords=out_coords, name=da.name, attrs=da.attrs
+    )
+
+
+def _interp_core(
+    data: np.ndarray,
+    dims: list[Hashable],
+    old_coords: Mapping[Hashable, xr.DataArray],
+    coords: dict[Hashable, float | np.ndarray | xr.DataArray],
+    bounds: Literal["fill", "clamp", "raise"]
+    | dict[Hashable, Literal["fill", "clamp", "raise"]] = "fill",
+    fill_value: float
+    | tuple[float, float]
+    | dict[Hashable, float | tuple[float, float]] = np.nan,
+) -> tuple[np.ndarray, list[Hashable], dict]:
+    """
+    Raw-numpy core of :func:`interp_dataarray`. Does the actual interpolation
+    work on plain numpy arrays, without constructing an intermediate
+    ``xr.DataArray``, so callers that need to chain several interpolation
+    steps can defer DataArray construction to the very end. See
+    :func:`interp_dataarray` for parameter semantics; ``old_coords`` is
+    ``da.coords`` (or any equivalent read-only mapping from dim name to
+    coordinate variable).
+    """
     # Normalize bounds to dict format
     if isinstance(bounds, str):
         bounds_dict: dict[Hashable, Literal["fill", "clamp", "raise"]] = dict.fromkeys(
@@ -473,7 +501,7 @@ def interp_dataarray(
             coords, fill_value
         )
     else:
-        fill_value_dict = dict(fill_value)  # type: ignore[arg-type]
+        fill_value_dict = dict(fill_value)
         for dim in coords:
             if dim not in fill_value_dict:
                 fill_value_dict[dim] = np.nan
@@ -483,10 +511,10 @@ def interp_dataarray(
     # array and record the metadata needed for the final DataArray wrap.
     interp_specs: list[dict] = []
     for dim, new_coords in coords.items():
-        if dim not in da.dims:
+        if dim not in dims:
             raise ValueError(
                 f"Dimension {dim!r} not found in DataArray. "
-                f"Available dimensions: {list(da.dims)}"
+                f"Available dimensions: {list(dims)}"
             )
         if isinstance(new_coords, xr.DataArray):
             spec = {
@@ -532,7 +560,7 @@ def interp_dataarray(
     # share the new dimension and reduce the array; processing larger grids
     # first means fewer lerp operations overall.
     def _interp_sort_key(spec: dict) -> tuple:
-        grid_size = da.sizes[spec["dim"]]
+        grid_size = data.shape[dims.index(spec["dim"])]
         query_size = len(spec["arr"])
         # (0, ...) = shrink/same -> first; (1, ...) = expand -> last
         # Within each group, larger grid_size first (hence negative)
@@ -552,9 +580,6 @@ def interp_dataarray(
     # --- Main interpolation loop on raw numpy arrays ---
     # `dims` tracks the current logical dimension order.
     # `data` is the raw ndarray; axes correspond 1-to-1 with `dims`.
-    dims: list[Hashable] = list(da.dims)
-    data: np.ndarray = da.values
-
     for group in interp_groups:
         # Check if this group can use the fast interpn path:
         # - Multiple specs in the group
@@ -568,7 +593,7 @@ def interp_dataarray(
             # Fast path: multi-dimensional interpn
             _, uniform_mode = _check_uniform_bounds(group, bounds_dict)
             data, dims = _interp_group_with_interpn(
-                data, dims, da, group, uniform_mode, fill_value_dict
+                data, dims, old_coords, group, uniform_mode, fill_value_dict
             )
             continue
 
@@ -583,7 +608,7 @@ def interp_dataarray(
             dim_fill_value = fill_value_dict.get(dim, np.nan)
 
             dim_axis = dims.index(dim)
-            old_coords_arr = da.coords[dim].values
+            old_coords_arr = old_coords[dim].values
 
             # Detect shared-dimension case: new_coords has a dim that already
             # exists in the current working set.
@@ -775,12 +800,12 @@ def interp_dataarray(
                         data = data.transpose(perm)
                     # dims unchanged (same names, same order)
 
-    # --- Wrap back into a DataArray ---
-    # Collect coordinates for the output: keep original coords whose dims
-    # are all still present, then add any new coords from interp targets.
+    # --- Assemble output coordinates ---
+    # Keep original coords whose dims are all still present, then add any
+    # new coords from interp targets.
     out_coords: dict = {
         coord_name: coord_val
-        for coord_name, coord_val in da.coords.items()
+        for coord_name, coord_val in old_coords.items()
         if all(d in dims for d in coord_val.dims)
     }
 
@@ -795,6 +820,4 @@ def interp_dataarray(
             # Plain array: attach as a coordinate on its own dim
             out_coords[dim] = (dim, spec["arr"])
 
-    return xr.DataArray(
-        data, dims=dims, coords=out_coords, name=da.name, attrs=da.attrs
-    )
+    return data, dims, out_coords

--- a/src/axsdb/units.py
+++ b/src/axsdb/units.py
@@ -10,6 +10,7 @@ library.
 
 from __future__ import annotations
 
+from functools import cache
 from typing import Any
 
 import pint
@@ -31,6 +32,47 @@ def set_unit_registry(ureg: pint.UnitRegistry | None) -> None:
     """
     global _ureg
     _ureg = ureg
+    _parse_units_cached.cache_clear()
+
+
+@cache
+def _parse_units_cached(unit_str: str) -> pint.Quantity:
+    return get_unit_registry()(unit_str)
+
+
+def parse_units(value: str | pint.Quantity) -> pint.Quantity:
+    """
+    Parse a unit string into a unit-only :class:`pint.Quantity` (magnitude
+    1), caching the result. This matches what ``get_unit_registry()(unit_str)``
+    returns, but avoids re-parsing the same string repeatedly.
+
+    Pint's unit-string parsing (tokenizing, name/symbol lookup) is
+    comparatively expensive, so repeatedly parsing the same string (e.g. a
+    NetCDF variable's ``units`` attribute, read on every call in a hot loop)
+    is wasteful. This caches the result globally, keyed on the string.
+
+    .. warning::
+        This cache is only invalidated by :func:`set_unit_registry`. If you
+        swap the active registry via Pint's own
+        :func:`pint.set_application_registry` instead of
+        :func:`set_unit_registry`, this cache keeps returning quantities
+        bound to the previous registry. Always call :func:`set_unit_registry`
+        when changing the registry used with this package.
+
+    Parameters
+    ----------
+    value : str or pint.Quantity
+        Unit string to parse, or an already-parsed unit quantity (returned
+        unchanged).
+
+    Returns
+    -------
+    pint.Quantity
+        The parsed unit quantity.
+    """
+    if isinstance(value, pint.Quantity):
+        return value
+    return _parse_units_cached(value)
 
 
 def get_unit_registry() -> pint.UnitRegistry:

--- a/src/axsdb/util.py
+++ b/src/axsdb/util.py
@@ -1,0 +1,22 @@
+"""
+Generic utilities.
+
+This module collects small, generic, reusable helpers that are not specific
+to any particular AxsDB domain concept (databases, interpolation, units...).
+"""
+
+from __future__ import annotations
+
+from cachetools import LRUCache
+
+
+class ClosingLRUCache(LRUCache):
+    """
+    LRUCache that closes evicted xarray Datasets, so that lazily opened files
+    do not stay open until Python garbage-collects them.
+    """
+
+    def popitem(self):
+        key, ds = super().popitem()
+        ds.close()
+        return key, ds

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,23 +123,62 @@ class TestCKDAbsorptionDatabase:
         z = thermoprops_us_standard.z.values
         assert sigma_a.values.shape == (wg[0].size, z.size)
 
+        # Regression test: the result must carry a "w" coordinate labeling
+        # the matched grid wavelength, like the pre-refactor
+        # .sel(method="nearest")-based implementation did.
+        assert "w" in sigma_a.coords
+        np.testing.assert_allclose(sigma_a.coords["w"].values, [349.9286])
+
+    def test_interp_thermophysical_raw_matches(
+        self,
+        absdb_ckd,
+        thermoprops_us_standard,
+        absorption_database_error_handler_config,
+    ):
+        # _interp_thermophysical_raw (numpy in/out) must produce the exact
+        # same result as _interp_thermophysical (DataArray in/out) for the
+        # same inputs.
+        error_handling_config = ErrorHandlingConfiguration.convert(
+            absorption_database_error_handler_config
+        )
+        ds = absdb_ckd.load_dataset("nanockd_v1-345_355.nc")
+        da = ds["sigma_a"].sel(w=350.0, method="nearest")
+
+        expected, expected_x_ds = absdb_ckd._interp_thermophysical(
+            ds, da, thermoprops_us_standard, error_handling_config
+        )
+
+        data, dims, out_coords, x_ds = absdb_ckd._interp_thermophysical_raw(
+            ds,
+            da.values,
+            list(da.dims),
+            da.coords,
+            thermoprops_us_standard,
+            error_handling_config,
+        )
+
+        assert x_ds == expected_x_ds
+        assert dims == list(expected.dims)
+        np.testing.assert_array_equal(data, expected.values)
+        assert set(out_coords) == set(expected.coords)
+
 
 def test_cache_clear(absdb_ckd):
     # Make a query to ensure that the cache is filling up
     absdb_ckd.load_dataset("nanockd_v1-345_355.nc")
-    assert absdb_ckd._cache.currsize > 0
+    assert absdb_ckd._fname_dataset_cache.currsize > 0
     # Clear the cache: it should be empty after that
     absdb_ckd.cache_clear()
-    assert absdb_ckd._cache.currsize == 0
+    assert absdb_ckd._fname_dataset_cache.currsize == 0
 
 
 def test_cache_reset(absdb_ckd):
     absdb_ckd.cache_reset(2)
-    assert absdb_ckd._cache.currsize == 0
-    assert absdb_ckd._cache.maxsize == 2
+    assert absdb_ckd._fname_dataset_cache.currsize == 0
+    assert absdb_ckd._fname_dataset_cache.maxsize == 2
     absdb_ckd.cache_reset(8)
-    assert absdb_ckd._cache.currsize == 0
-    assert absdb_ckd._cache.maxsize == 8
+    assert absdb_ckd._fname_dataset_cache.currsize == 0
+    assert absdb_ckd._fname_dataset_cache.maxsize == 8
 
 
 @pytest.mark.parametrize("absdb", ["mono", "ckd"], indirect=True)
@@ -235,3 +274,46 @@ def test_bounds_policies(absdb, thermoprops_us_standard):
     result_ignore = _eval(absdb, thermoprops_us_standard, config_ignore)
 
     np.testing.assert_array_equal(result_ignore.values, result_warn.values)
+
+
+@pytest.mark.parametrize("absdb", ["mono", "ckd"], indirect=True)
+def test_bounds_clamp_mode(absdb, thermoprops_us_standard):
+    """
+    Regression test: a bounds policy configured with mode="clamp" must
+    actually clamp out-of-bounds queries to the grid bounds, rather than
+    silently behaving like "fill" (or crashing). ``BoundsPolicy.mode`` is
+    stored as a ``BoundsMode`` enum internally, which must be converted to
+    its string value before reaching the interpolation layer.
+    """
+    fill_sentinel = -12345.0
+    config_clamp = {
+        "p": {"missing": "raise", "scalar": "raise", "bounds": {"mode": "clamp"}},
+        "t": {"missing": "raise", "scalar": "raise", "bounds": {"mode": "clamp"}},
+        "x": {"missing": "ignore", "scalar": "ignore", "bounds": {"mode": "clamp"}},
+    }
+    config_fill = {
+        "p": {
+            "missing": "raise",
+            "scalar": "raise",
+            "bounds": {"mode": "fill", "fill_value": fill_sentinel},
+        },
+        "t": {
+            "missing": "raise",
+            "scalar": "raise",
+            "bounds": {"mode": "fill", "fill_value": fill_sentinel},
+        },
+        "x": {
+            "missing": "ignore",
+            "scalar": "ignore",
+            "bounds": {"mode": "fill", "fill_value": fill_sentinel},
+        },
+    }
+
+    result_clamp = _eval(absdb, thermoprops_us_standard, config_clamp)
+    result_fill = _eval(absdb, thermoprops_us_standard, config_fill)
+
+    # Sanity check: this profile does have out-of-bounds altitudes against
+    # the tiny test databases, otherwise this test would vacuously pass.
+    assert np.any(result_fill.values == fill_sentinel)
+    # Clamping must never leak the raw fill sentinel.
+    assert not np.any(result_clamp.values == fill_sentinel)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,41 @@
+"""
+Tests for axsdb.util.
+"""
+
+from __future__ import annotations
+
+from axsdb.util import ClosingLRUCache
+
+
+class TestClosingLRUCache:
+    class FakeDataset:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    def test_closes_on_eviction(self):
+        cache = ClosingLRUCache(maxsize=1)
+        ds1 = self.FakeDataset()
+        ds2 = self.FakeDataset()
+
+        cache["1"] = ds1
+        cache["2"] = ds2  # evicts "1" (maxsize=1)
+
+        assert ds1.closed
+        assert not ds2.closed
+        assert "2" in cache
+
+    def test_closes_on_clear(self):
+        cache = ClosingLRUCache(maxsize=4)
+        ds1 = self.FakeDataset()
+        ds2 = self.FakeDataset()
+
+        cache["1"] = ds1
+        cache["2"] = ds2
+
+        cache.clear()
+
+        assert ds1.closed and ds2.closed
+        assert len(cache) == 0


### PR DESCRIPTION
This PR speeds up `eval_sigma_a_ckd()`/`eval_sigma_a_mono()` by moving the hot path off xarray's generic dispatch onto a raw-numpy pipeline, adds dataset- and plan-level caching, and fixes a pre-existing `BoundsPolicy` bug.

## Performance

* **Bypass xarray dispatch.** `DataArray.interp()` runs a sortby/align/deepcopy pass on every call: the g-dimension interp is replaced with our own `interp_dataarray()`, skipping xarray's alignment machinery.
* **Raw-numpy core.** `eval_sigma_a_ckd()` now stays on raw numpy end-to-end (nearest-bin lookup via `searchsorted`, plus g and thermophysical interpolation) instead of chained `DataArray.interp()` calls. `interp_dataarray()` is split into a raw-numpy core plus a thin wrapper.
* **Thermophysical interpolation plan cache.** The `_interp_thermophysical()` function rebuilt structural metadata and redid file lookups on every (w, g) call, though most of that depends only on the loaded file. Now, it caches the ds/thermoprops/config-derived interpolation plan, i.e. the thermophysics-related coordinate values (cache is keyed via `attrs.astuple()`, carried in a `NamedTuple`); per-call bounds validation (raise/warn side effects) still runs every time.
* **Per-wavelength dataset resolution** (`_resolve_dataset()`) to cut redundant `lookup_filenames()` calls when sweeping g at fixed w.
* **xarray-aware LRU cache** in `util.py`; dataset loading is routed through it. `cache_reset()` maxsize applies to all managed caches; cache_close clears dataset caches after closing handles.
* **Cache Pint unit-string parsing.** Instead of re-parsing Pint unit strings every time units are inferred from dataset metadata using the `Unit()` constructor, unit objects are now stored in a cache keyed with string values.

## Correctness fix

* **`BoundsPolicy` mode="clamp" silently ignored.** `BoundsPolicy.mode` is a `BoundsMode` enum, but the interpolation paths compare it against literal strings "fill"/"clamp"/"raise", and `core.py` passed the enum member straight through. Since `BoundsMode.CLAMP != "clamp"`, a `mode="clamp"` policy was either treated as "fill" (interpn path) or raised `ValueError` (sequential path). The fix consists in storing `policy.mode.value` (plain string) in the bounds dictionary. A new regression test `test_bounds_clamp_mode` checks that "clamp" never leaks a "fill" sentinel, for mono and CKD databases.

## AI usage disclosure

Initial code generated with Claude Opus 4.8 and Claude Sonnet 5, reviewed, refactored, tested and benchmarked manually.